### PR TITLE
Seperate binary and library dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,23 @@ version = "1.1.1"
 edition = "2018"
 license = "MIT"
 
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+ssh2 = { version = "0.9" }
+serde_json = { version = "1.0" }
+
+dirs = { version = "4.0", optional = true }
+rpassword = { version = "5.0", optional = true }
+
+[features]
+bin = ["dirs", "rpassword"]
+
 [lib]
 name = "mtc"
 
 [[bin]]
 name = "mtc"
 path = "src/main.rs"
+required-features = ["bin"]
 
-[dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-ssh2 = { version = "0.9" }
-serde_json = "1.0"
-dirs = "4.0"
-rpassword = "5.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ there is probably not the most well written since I didn't bother to do anything
 You can install MTC using the following command. The same command is used for updating MTC as well.
 
 ```
-cargo install --git https://github.com/Windore/mtc.git
+cargo install --git https://github.com/Windore/mtc.git --features bin
 ```
 
 ## Usage


### PR DESCRIPTION
Now binary dependencies are behind a "bin" feature.